### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/elasticsearch_helper_instant.info.yml
+++ b/elasticsearch_helper_instant.info.yml
@@ -1,8 +1,9 @@
 name: Elasticsearch Helper Instant
 type: module
 description: Instant search functionality based on elasticssearch_helper_content.module.
+core_version_requirement: ^8 || ^9
 core: 8.x
 package: ElasticSearch Helper
 dependencies:
-  - elasticsearch_helper
-  - elasticsearch_helper_content
+  - drupal:elasticsearch_helper
+  - drupal:elasticsearch_helper_content


### PR DESCRIPTION
This PR adds Drupal 9 readiness for elasticsearch_helper_index_alias module.

Note:
Marking core_version_requirement: ^8 || ^9 as there is no deprecations introduced after 8.0.x

Checked with Upgrade status